### PR TITLE
Add composing of images

### DIFF
--- a/isototest/Cargo.toml
+++ b/isototest/Cargo.toml
@@ -13,6 +13,7 @@ log = "0.4.22"
 tokio = "1.38.1"
 vnc-rs = "0.5.1"
 env_logger = { version= "0.10", optional=true }
+chrono = "0.4.38"
 
 [dev-dependencies]
 mockito = "1.4.0"

--- a/isototest/src/lib.rs
+++ b/isototest/src/lib.rs
@@ -17,7 +17,6 @@
 //! use isototest::action::view::read_screen;
 //! use tokio::{self};
 //! use std::process::exit;
-//! use std::time::Duration;
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -31,20 +30,6 @@
 //!         Err(e) => {
 //!             eprintln!("[Error] {:?}", e);
 //!             exit(1)
-//!         }
-//!     };
-//!
-//!     // Request screenshot from the remote machine, save the resolution as the client can not
-//!     // request it again as long as it does not change.
-//!     let res;
-//!     let mut resolution = match read_screen(&client, "screenshot.png", None, Duration::from_secs(1)).await {
-//!         Ok(x) => {
-//!             println!("Screenshot received!");
-//!             res = x;
-//!         }
-//!         Err(e) => {
-//!             eprintln!("{}", e);
-//!             exit(1);
 //!         }
 //!     };
 //!


### PR DESCRIPTION
## What?

As described in https://github.com/os-autoinst/isotest-ng/issues/1, the VNC server only sends the pixels which have changed since the last request.
One way to fix this, according to my proposal in https://github.com/os-autoinst/isotest-ng/issues/9 is to "layer" the new image data onto a copy of the old image and save it separately.

Fixes: https://github.com/os-autoinst/isotest-ng/issues/9

TODO:
- [x] Implement function to combine image data.
- [x] Integrate function into existing `read_screen` function.

